### PR TITLE
Update MazeRunner.java

### DIFF
--- a/MazeRunner.java
+++ b/MazeRunner.java
@@ -77,7 +77,7 @@ public class MazeRunner {
         } else if (moves==100) {
             System.out.println("Oh no! You took too long to escape, and now the maze exite is cloased FOREVER>:[");
         }
-        if (moves==100) {
+        if (moves>100) {
             System.out.println("Sorry, but you didn't escape in time- you lose!");
             playing = false;
         }


### PR DESCRIPTION
" Note that after 100 moves, if you still haven’t escaped you need to end to game and tell the user they lost, and then allow the program to exit. When this happens print the following message:
Sorry, but you didn't escape in time- you lose! "

The above instruction clearly states that we have to preform this operation for moves > 100. 